### PR TITLE
Add direct link to templated issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ If you'd like to propose new work or get in touch with the team, head over to di
 
 ### Template for creating a new issue
 
+[Click here](https://github.com/mozilla/participation-org/issues/new?body=%23%23+Goal%3a+%0D%0A[One+line+goal+description]+%0D%0A%0D%0A%23%23+Success%3a%0D%0A++[What+would+success+look+like]+%0D%0A%0D%0A%23%23+Related+Issues+%26+Links%3a+%0D%0A[Reference+meta+issues+and+past+issues]+%23%0D%0A%0D%0A%23%23+Roles%3a%0D%0AOwner%3a+%0D%0AInvolved%3a+%0D%0A%0D%0A%23%23+Required%3a+%0D%0A-+[+]+Put+mittens+on+all+of+the+kittens+%28owner%2c+[small%2c+medium%2c+large]%2c+Due%3a+Aug+7th%29+%0D%0A-+[+]+Put+mittens+on+all+of+the+kittens+%28owner%2c+[small%2c+medium%2c+large]%2c+Due%3a+Aug+7th%29+%0D%0A-+[+]+Put+mittens+on+all+of+the+kittens+%28owner%2c+[small%2c+medium%2c+large]%2c+Due%3a+Aug+7th%29+%0D%0A) to create a new issue with the template.
+
 ```
 ## Goal: 
 [One line goal description] 


### PR DESCRIPTION
by passing the url encoded template to body parameter of the new issue link, we can avoid the need to copy paste.

[Click here for example](https://github.com/mozilla/participation-org/issues/new?body=%23%23+Goal%3a+%0D%0A[One+line+goal+description]+%0D%0A%0D%0A%23%23+Success%3a%0D%0A++[What+would+success+look+like]+%0D%0A%0D%0A%23%23+Related+Issues+%26+Links%3a+%0D%0A[Reference+meta+issues+and+past+issues]+%23%0D%0A%0D%0A%23%23+Roles%3a%0D%0AOwner%3a+%0D%0AInvolved%3a+%0D%0A%0D%0A%23%23+Required%3a+%0D%0A-+[+]+Put+mittens+on+all+of+the+kittens+%28owner%2c+[small%2c+medium%2c+large]%2c+Due%3a+Aug+7th%29+%0D%0A-+[+]+Put+mittens+on+all+of+the+kittens+%28owner%2c+[small%2c+medium%2c+large]%2c+Due%3a+Aug+7th%29+%0D%0A-+[+]+Put+mittens+on+all+of+the+kittens+%28owner%2c+[small%2c+medium%2c+large]%2c+Due%3a+Aug+7th%29+%0D%0A)
